### PR TITLE
添加匹配尖括号格式图片链接的功能；修复图片文件带有大写字母时会被错误地清理的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ Get details in the extension, some of setting as below:
 
 1. removeFolder: The folder where image will move to when clean local image folder
 2. hasBracket: Whether the image path include right bracket
-3. imageSaveFolder: Local folder which the images will save to, support absolute or relative path. support `<filename>` and date format `<YYYYMMDD>` variable (dayjs)
-4. updateLink: Whether update the picture link in md file(Clean,Download,Upload,Move)
-5. skipSelectChange: Whether still update picture link when selection/position changed
-6. rename: Whether rename the image files(Download,Upload,Move
-7. remotePath: Which be added at beginning of PicBed path, support `<filename>` and date format `<YYYYMMDD>` variable (dayjs)
-8. clipboardPath: Clipboard image's path and name, support `<filename>` and date format`<YYYYMMDD>` variable (dayjs)
-9. urlFormatted: Whether escape image URL when insert local image
+3. matchAngleBrackets: Whether match the image link in angle brackets
+4. imageSaveFolder: Local folder which the images will save to, support absolute or relative path. support `<filename>` and date format `<YYYYMMDD>` variable (dayjs)
+5. updateLink: Whether update the picture link in md file(Clean,Download,Upload,Move)
+6. skipSelectChange: Whether still update picture link when selection/position changed
+7. rename: Whether rename the image files(Download,Upload,Move
+8. remotePath: Which be added at beginning of PicBed path, support `<filename>` and date format `<YYYYMMDD>` variable (dayjs)
+9. clipboardPath: Clipboard image's path and name, support `<filename>` and date format`<YYYYMMDD>` variable (dayjs)
+10. urlFormatted: Whether escape image URL when insert local image
 
 ## Known Issues
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -55,13 +55,14 @@ picgo支持多种图床和各种插件，比如通过插件 picgo-plugin-ftp-upl
 
 1. removeFolder: 本地图片目录清理时，其他图片移动的目标文件夹
 2. hasBracket: 图片路径中是否包括右括号
-3. imageSaveFolder: 图片要保存到的位置,默认以md文件名做文件夹，支持绝对路径和相对路径，支持文件名 `<filename>`和日期 `<YYYYMMDD>`变量(dayjs)
-4. updateLink: 上传/下载/移动时是否需要更新md文件的图片链接
-5. skipSelectChange: 当光标或选择范围改变后是否依然更新图片链接
-6. rename: 上传/下载/移动图片时是否需要重命名图片
-7. remotePath: 图床上需要添加的远程路径，可区分不同md文件的图片，支持文件名 `<filename>`和日期 `<YYYYMMDD>`变量(dayjs)。
-8. clipboardPath: 剪切板图片的路径和名称，支持文件名 `<filename>`和日期 `<YYYYMMDD>`变量(dayjs)。
-9. urlFormatted: 图片URL格式是否转义，转义后有兼容性强可读性弱，插入本地图片时生效
+3. matchAngleBrackets: 是否匹配尖括号中的图片链接
+4. imageSaveFolder: 图片要保存到的位置,默认以md文件名做文件夹，支持绝对路径和相对路径，支持文件名 `<filename>`和日期 `<YYYYMMDD>`变量(dayjs)
+5. updateLink: 上传/下载/移动时是否需要更新md文件的图片链接
+6. skipSelectChange: 当光标或选择范围改变后是否依然更新图片链接
+7. rename: 上传/下载/移动图片时是否需要重命名图片
+8. remotePath: 图床上需要添加的远程路径，可区分不同md文件的图片，支持文件名 `<filename>`和日期 `<YYYYMMDD>`变量(dayjs)。
+9. clipboardPath: 剪切板图片的路径和名称，支持文件名 `<filename>`和日期 `<YYYYMMDD>`变量(dayjs)。
+10. urlFormatted: 图片URL格式是否转义，转义后有兼容性强可读性弱，插入本地图片时生效
 
 ## 已知问题
 

--- a/i18n/zh-cn/package.i18n.json
+++ b/i18n/zh-cn/package.i18n.json
@@ -13,6 +13,7 @@
     
     "markdown-image-manage.removeFolder": "本地图片目录清理时，其他图片移动的目标文件夹",
     "markdown-image-manage.hasBracket": "图片路径中是否包括右括号",
+    "markdown-image-manage.matchAngleBrackets": "是否匹配尖括号格式的图片链接",
     "markdown-image-manage.imageSaveFolder": "图片要保存到的位置,默认以md文件名做文件夹，支持绝对路径和相对路径，支持文件名<filename>和日期<YYYYMMDD>变量(dayjs)",
     "markdown-image-manage.updateLink": "上传/下载/移动时是否需要更新md文件的图片链接",
     "markdown-image-manage.skipSelectChange": "当光标或选择范围改变后是否依然更新图片链接",

--- a/package-linkpicgo.json
+++ b/package-linkpicgo.json
@@ -142,6 +142,11 @@
 					"enum": ["auto", "yes", "no"],
 					"description": "%markdown-image-manage.hasBracket%"
 				},
+        "markdown-image-manage.matchAngleBrackets": {
+					"type": "boolean",
+					"default": true,
+					"description": "%markdown-image-manage.matchAngleBrackets%"
+				},
         "markdown-image-manage.imageSaveFolder": {
 					"type": "string",
 					"default": "<filename>.assets",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-image-manage",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-image-manage",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,11 @@
           ],
           "description": "%markdown-image-manage.hasBracket%"
         },
+        "markdown-image-manage.matchAngleBrackets": {
+					"type": "boolean",
+					"default": true,
+					"description": "%markdown-image-manage.matchAngleBrackets%"
+				},
         "markdown-image-manage.imageSaveFolder": {
           "type": "string",
           "default": "<filename>.assets",

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,6 +13,7 @@
 
     "markdown-image-manage.removeFolder": "The folder where image will move to when clean local image folder",
     "markdown-image-manage.hasBracket": "Whether the image path include right bracket",
+    "markdown-image-manage.matchAngleBrackets": "Whether the image path match angle brackets format",
     "markdown-image-manage.imageSaveFolder": "Local folder which the images will save to, support absolute or relative path. support <filename> and date format<YYYYMMDD> variable (dayjs)",
     "markdown-image-manage.updateLink": "Whether update the picture link in md file(Clean,Download,Upload,Move)",
     "markdown-image-manage.skipSelectChange": "Whether still update picture link when selection/position changed",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -12,6 +12,7 @@
 	"markdown-image-manage.menuConvertLink": "MIM:所选路径相对<->绝对",
 	"markdown-image-manage.removeFolder": "本地图片目录清理时，其他图片移动的目标文件夹",
 	"markdown-image-manage.hasBracket": "图片路径中是否包括右括号",
+	"markdown-image-manage.matchAngleBrackets": "是否匹配尖括号格式的图片链接",
 	"markdown-image-manage.imageSaveFolder": "图片要保存到的位置,默认以md文件名做文件夹，支持绝对路径和相对路径，支持文件名<filename>和日期<YYYYMMDD>变量(dayjs)",
 	"markdown-image-manage.updateLink": "上传/下载/移动时是否需要更新md文件的图片链接",
 	"markdown-image-manage.skipSelectChange": "当光标或选择范围改变后是否依然更新图片链接",

--- a/src/clean.ts
+++ b/src/clean.ts
@@ -71,7 +71,10 @@ function doFile(picArr: string[]) {
         var filePath = path.join(parentPath, name);
         var stat = fs.statSync(filePath);
         if (stat.isFile()) {
-            var orifile = name.toLowerCase();
+            // 不太懂这里为什么要toLowerCase，这反而会导致文件名带有大写字母的图片被误判删除
+            // 感觉是Bug，我先注释了
+            // var orifile = name.toLowerCase();
+            var orifile = name;
             var extName = path.extname(orifile);
             if (extArr.indexOf(extName) > -1) // 必须是图片
             {

--- a/src/common.ts
+++ b/src/common.ts
@@ -23,6 +23,7 @@ export let urlFormatted = true; // URL格式神需要转义
 let docTextEditor: vscode.TextEditor | undefined; // 选择的MD文件
 let docPreSelection: vscode.Selection | undefined; // 选择的范围
 let imagePathBracket = 'auto'; // 文件名中包含括号
+let imageMatchAngleBrackets = true; // 是否支持尖括号格式图片
 
 export function getImages(selectFlag: boolean = false): { local: string[], net: string[], invalid: string[], mapping: Record<string, any>, content: string } {
     var picArrLocal: string[] = [];
@@ -74,6 +75,13 @@ export function getImages(selectFlag: boolean = false): { local: string[], net: 
         // const imgList = str.match(pattern) || [] // ![img](http://hello.com/image.png)
         // let tmpPicArrNet: string[] = [],tmpPicArrLocal: string[]=[],tmpPicArrInvalid: string[]=[],tmpOriMapping={};
         findImage(reg, str, imagePathBracket == 'auto', picArrNet, picArrLocal, picArrInvalid, oriMapping);
+        
+        // 如果需要匹配尖括号格式的图片，重新设置正则并再次匹配
+        if (imageMatchAngleBrackets) {
+            reg = /<img src="(.+?)" .*?>/g; // 匹配尖括号格式的图片
+            findImage(reg, str, false, picArrNet, picArrLocal, picArrInvalid, oriMapping);
+        }
+
         /*if(picArrInvalid.length>0 && )
         {
             // 尝试有括号重新查找
@@ -257,10 +265,11 @@ export let logger = {
     }
 };
 // 设置相关内部变量
-export function setPara(bracket: string, ren: boolean, read: boolean, skip: boolean
+export function setPara(bracket: string, matchAngleBrackets: boolean,ren: boolean, read: boolean, skip: boolean
     , local: string, remote: string, rem: string
     , dl: number, ul: number, cb: string, urlf: boolean) {
     imagePathBracket = bracket;
+    imageMatchAngleBrackets = matchAngleBrackets;
     rename = ren;
     skipSelectChange = skip;
     readonly = !read; // 含义相反

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export function initPara() {
     clearMsg();
     let extendName = 'markdown-image-manage';
     let hasBracket = vscode.workspace.getConfiguration(extendName).get('hasBracket') as string;
+    let matchAngleBrackets = vscode.workspace.getConfiguration(extendName).get('matchAngleBrackets') as boolean;
     let updateLink = vscode.workspace.getConfiguration(extendName).get('updateLink') as boolean;
     let skipSelectChange = vscode.workspace.getConfiguration(extendName).get('skipSelectChange') as boolean;
     let rename = vscode.workspace.getConfiguration(extendName).get('rename') as boolean;
@@ -81,7 +82,7 @@ export function initPara() {
     if(dlTimeout<=0) {dlTimeout =10;}
     if(ulTimeout<=0) {ulTimeout =10;}
     //const isAsync: boolean = vscode.workspace.getConfiguration().get('downloadImageInMarkdown.isAsync') as boolean;
-    setPara(hasBracket, rename, updateLink,skipSelectChange, imageSaveFolder, remotePath
+    setPara(hasBracket, matchAngleBrackets,rename, updateLink,skipSelectChange, imageSaveFolder, remotePath
         , removeFolder,dlTimeout,ulTimeout,clipboardPath,urlFormatted);
 
     let file = vscode.window.activeTextEditor?.document.uri.fsPath || '';


### PR DESCRIPTION
在此提交前，MIM无法匹配尖括号格式的MD文件，比如：`<img src="Images/image.png" style="zoom:50%;" alt="image" />`  ，这使得在分析图片链接和清理多余图片的功能中，这种格式的图片会被错误地清除。
同时，在文件 clean.ts 中，似乎有一次多余的转全小写操作，导致文件名带有大写字母的图片会被错误地删除。
本次提交已将上述两个问题修复。